### PR TITLE
Implement persistent device storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## API server
+
+The `api` folder contains a small Express server used to persist
+device information in the MariaDB database. The React frontend
+communicates with this API to load and save devices.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/18b30a26-58c8-4510-9eac-aeca1440f0ba) and click on Share -> Publish.

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --only=production
+COPY . .
+EXPOSE 3000
+CMD ["npm","start"]

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,78 @@
+import express from 'express';
+import cors from 'cors';
+import mysql from 'mysql2/promise';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(cors());
+app.use(express.json());
+
+const pool = mysql.createPool({
+  host: process.env.DB_HOST || 'mariadb',
+  user: process.env.DB_USER || 'mikrotik_user',
+  password: process.env.DB_PASSWORD || 'mikrotik_pass123',
+  database: process.env.DB_NAME || 'mikrotik_dashboard',
+  waitForConnections: true,
+  connectionLimit: 10,
+});
+
+app.get('/devices', async (req, res) => {
+  try {
+    const [rows] = await pool.query('SELECT * FROM mikrotik_devices');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
+app.post('/devices', async (req, res) => {
+  const { name, ip, port, username, password, useHttps } = req.body;
+  if (!name || !ip || !username || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  try {
+    const [result] = await pool.execute(
+      `INSERT INTO mikrotik_devices (name, ip_address, port, username, password_encrypted, use_https)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [name, ip, port || 8728, username, password, !!useHttps]
+    );
+    const [rows] = await pool.query('SELECT * FROM mikrotik_devices WHERE id = ?', [result.insertId]);
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
+app.put('/devices/:id', async (req, res) => {
+  const id = req.params.id;
+  const { name, ip, port, username, password, useHttps } = req.body;
+  try {
+    await pool.execute(
+      `UPDATE mikrotik_devices SET name=?, ip_address=?, port=?, username=?, password_encrypted=?, use_https=? WHERE id=?`,
+      [name, ip, port, username, password, !!useHttps, id]
+    );
+    const [rows] = await pool.query('SELECT * FROM mikrotik_devices WHERE id = ?', [id]);
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
+app.delete('/devices/:id', async (req, res) => {
+  const id = req.params.id;
+  try {
+    await pool.execute('DELETE FROM mikrotik_devices WHERE id=?', [id]);
+    res.status(204).end();
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`API listening on port ${port}`);
+});

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mikrotik-api",
+  "version": "1.0.0",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "mysql2": "^3.9.7"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,10 +29,28 @@ services:
       - "80:80"
     depends_on:
       - mariadb
+      - mikrotik-api
     networks:
       - mikrotik-network
     environment:
       - NODE_ENV=production
+
+  # API backend
+  mikrotik-api:
+    build: ./api
+    container_name: mikrotik-api
+    restart: unless-stopped
+    environment:
+      DB_HOST: mariadb
+      DB_USER: mikrotik_user
+      DB_PASSWORD: mikrotik_pass123
+      DB_NAME: mikrotik_dashboard
+    depends_on:
+      - mariadb
+    ports:
+      - "3000:3000"
+    networks:
+      - mikrotik-network
 
   # phpMyAdmin para administrar la base de datos
   phpmyadmin:

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,6 +16,13 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # Proxy API requests to the backend service
+    location /api/ {
+        proxy_pass http://mikrotik-api:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     # Configuración de seguridad
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;

--- a/src/pages/Devices.tsx
+++ b/src/pages/Devices.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -13,6 +13,30 @@ import { useToast } from '@/hooks/use-toast';
 
 const Devices = () => {
   const [devices, setDevices] = useState<MikroTikDevice[]>([]);
+
+  useEffect(() => {
+    fetch('/api/devices')
+      .then((r) => r.json())
+      .then((data) =>
+        setDevices(
+          data.map((d: any) => ({
+            id: d.id.toString(),
+            name: d.name,
+            ip: d.ip_address,
+            port: d.port,
+            username: d.username,
+            password: d.password_encrypted,
+            useHttps: !!d.use_https,
+            status: d.status || 'offline',
+            lastSeen: d.last_seen ? new Date(d.last_seen) : new Date(),
+            version: d.version || 'Desconocido',
+            board: d.board || 'Desconocido',
+            uptime: d.uptime || '0d 0h 0m',
+          }))
+        )
+      )
+      .catch((e) => console.error('Failed to load devices', e));
+  }, []);
 
   const [newDevice, setNewDevice] = useState<Partial<MikroTikDevice>>({
     name: '',
@@ -28,7 +52,7 @@ const Devices = () => {
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const { toast } = useToast();
 
-  const handleAddDevice = () => {
+  const handleAddDevice = async () => {
     if (!newDevice.name || !newDevice.ip || !newDevice.username || !newDevice.password) {
       toast({
         title: "Error",
@@ -37,23 +61,35 @@ const Devices = () => {
       });
       return;
     }
-
-    const device: MikroTikDevice = {
-      id: Date.now().toString(),
-      name: newDevice.name!,
-      ip: newDevice.ip!,
-      port: newDevice.port || 8728,
-      username: newDevice.username!,
-      password: newDevice.password!,
-      useHttps: newDevice.useHttps || false,
-      status: 'offline',
-      lastSeen: new Date(),
-      version: 'Desconocido',
-      board: 'Desconocido',
-      uptime: '0d 0h 0m'
-    };
-
-    setDevices([...devices, device]);
+    const res = await fetch('/api/devices', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: newDevice.name,
+        ip: newDevice.ip,
+        port: newDevice.port,
+        username: newDevice.username,
+        password: newDevice.password,
+        useHttps: newDevice.useHttps,
+      }),
+    });
+    if (res.ok) {
+      const saved = await res.json();
+      setDevices([...devices, {
+        id: saved.id.toString(),
+        name: saved.name,
+        ip: saved.ip_address,
+        port: saved.port,
+        username: saved.username,
+        password: saved.password_encrypted,
+        useHttps: !!saved.use_https,
+        status: saved.status || 'offline',
+        lastSeen: saved.last_seen ? new Date(saved.last_seen) : new Date(),
+        version: saved.version || 'Desconocido',
+        board: saved.board || 'Desconocido',
+        uptime: saved.uptime || '0d 0h 0m',
+      }]);
+    }
     setNewDevice({
       name: '',
       ip: '',
@@ -75,7 +111,7 @@ const Devices = () => {
     setIsEditDialogOpen(true);
   };
 
-  const handleUpdateDevice = () => {
+  const handleUpdateDevice = async () => {
     if (!editingDevice || !editingDevice.name || !editingDevice.ip || !editingDevice.username || !editingDevice.password) {
       toast({
         title: "Error",
@@ -84,11 +120,38 @@ const Devices = () => {
       });
       return;
     }
+    const res = await fetch(`/api/devices/${editingDevice.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: editingDevice.name,
+        ip: editingDevice.ip,
+        port: editingDevice.port,
+        username: editingDevice.username,
+        password: editingDevice.password,
+        useHttps: editingDevice.useHttps,
+      }),
+    });
+    if (res.ok) {
+      const saved = await res.json();
+      setDevices(devices.map(device =>
+        device.id === editingDevice.id ? {
+          id: saved.id.toString(),
+          name: saved.name,
+          ip: saved.ip_address,
+          port: saved.port,
+          username: saved.username,
+          password: saved.password_encrypted,
+          useHttps: !!saved.use_https,
+          status: saved.status || 'offline',
+          lastSeen: saved.last_seen ? new Date(saved.last_seen) : new Date(),
+          version: saved.version || 'Desconocido',
+          board: saved.board || 'Desconocido',
+          uptime: saved.uptime || '0d 0h 0m',
+        } : device
+      ));
+    }
 
-    setDevices(devices.map(device => 
-      device.id === editingDevice.id ? editingDevice : device
-    ));
-    
     setEditingDevice(null);
     setIsEditDialogOpen(false);
 
@@ -98,8 +161,9 @@ const Devices = () => {
     });
   };
 
-  const deleteDevice = (deviceId: string) => {
+  const deleteDevice = async (deviceId: string) => {
     const device = devices.find(d => d.id === deviceId);
+    await fetch(`/api/devices/${deviceId}`, { method: 'DELETE' });
     setDevices(devices.filter(device => device.id !== deviceId));
     toast({
       title: "Dispositivo eliminado",


### PR DESCRIPTION
## Summary
- add Express API in `api/` to connect to MariaDB
- proxy API requests through nginx
- build new `mikrotik-api` service in compose
- integrate device CRUD calls to backend
- document API folder in README

## Testing
- `npm install` *(fails: registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685f2bcd0d6c83239ff76f3f436b0a5c